### PR TITLE
Add modular DocVision document analysis React component

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -66,3 +66,34 @@ export function DashboardView() {
   // render from `data`
 }
 ```
+
+## DocVision single-file analysis UI
+
+The `src/docvision` directory contains a self-contained React experience for uploading PDFs/PPTX files, extracting their
+contents with `pdfjs-dist`, `jszip`, `fast-xml-parser`, and optional OCR via `tesseract.js`, and forwarding structured
+prompts to multimodal LLM providers (OpenAI, Gemini, xAI Grok, Alibaba Qwen). The entry point is the `DocVisionApp`
+component, exported from `src/docvision/index.ts`.
+
+Key characteristics:
+
+- **Modular data pipeline** – parsing, OCR, prompt construction, and provider adapters live in dedicated modules to keep the
+  React tree lightweight.
+- **Resilient UX** – drag-and-drop uploads, removable file list, timestamped activity log, and inline progress banner make it
+  easier to understand extraction steps and troubleshoot failures.
+- **Provider flexibility** – API keys persist in local storage only; adapters use simple `fetch` calls so you can swap in
+  official SDKs or proxy calls through your backend for CORS control.
+
+To embed it in the existing UI, import the component where appropriate (for instance, a new route or tab) and ensure the
+dependencies are installed:
+
+```bash
+npm install pdfjs-dist tesseract.js jszip fast-xml-parser
+```
+
+```tsx
+import { DocVisionApp } from "./docvision";
+
+export default function AnalysisRoute() {
+  return <DocVisionApp />;
+}
+```

--- a/ui/src/docvision/DocVisionApp.tsx
+++ b/ui/src/docvision/DocVisionApp.tsx
@@ -1,0 +1,442 @@
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { extractFromPDF } from "./pdf";
+import { extractFromPPTX } from "./pptx";
+import { runOCR } from "./ocr";
+import { buildPrompt } from "./prompt";
+import { LS_KEYS, useLocalStorage } from "./storage";
+import { providerHandlers, PROVIDERS } from "./providers";
+import type { ExtractedUnit, Level, Provider } from "./types";
+
+type ApiKeys = Record<string, string>;
+
+type ActivityEntry = {
+  id: string;
+  message: string;
+  ts: number;
+};
+
+function useActivityLog() {
+  const [entries, setEntries] = useState<ActivityEntry[]>([]);
+  const push = useCallback((message: string) => {
+    setEntries((prev) => [
+      ...prev,
+      { id: `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`, message, ts: Date.now() },
+    ]);
+  }, []);
+  const clear = useCallback(() => setEntries([]), []);
+  const text = useMemo(
+    () => entries.map((entry) => new Date(entry.ts).toLocaleTimeString() + " | " + entry.message).join("\n"),
+    [entries]
+  );
+  return { entries, push, clear, text } as const;
+}
+
+function describeFile(file: File) {
+  const size = file.size / (1024 * 1024);
+  return `${file.name} (${size.toFixed(1)} MB)`;
+}
+
+export default function DocVisionApp() {
+  const [provider, setProvider] = useLocalStorage<Provider>(LS_KEYS.provider, "openai");
+  const [apiKeys, setApiKeys] = useLocalStorage<ApiKeys>(LS_KEYS.apiKeys, {} as ApiKeys);
+  const [files, setFiles] = useState<File[]>([]);
+  const [units, setUnits] = useState<ExtractedUnit[]>([]);
+  const [insights, setInsights] = useState("");
+  const [goal, setGoal] = useState("Extract insights from uploaded docs.");
+  const [ask, setAsk] = useState("Summarize trends, KPIs, and table values with citations.");
+  const [level, setLevel] = useState<Level>("overview");
+  const [modelExtras, setModelExtras] = useState("");
+  const [useOCR, setUseOCR] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [progress, setProgress] = useState<string | null>(null);
+  const { text: logText, push: pushLog, clear: clearLog } = useActivityLog();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const providerOptions = useMemo(() => Object.values(PROVIDERS), []);
+  const providerConfig = PROVIDERS[provider];
+  const unitCount = units.length;
+
+  const onPutKey = useCallback((envKey: string, value: string) => {
+    setApiKeys((prev) => ({ ...prev, [envKey]: value }));
+  }, [setApiKeys]);
+
+  const onFilesChosen = useCallback((fileList: FileList | null) => {
+    if (!fileList) return;
+    const accepted = Array.from(fileList).filter((file) => /\.(pdf|pptx)$/i.test(file.name));
+    if (!accepted.length) {
+      pushLog("No supported files selected. Please choose PDF or PPTX.");
+      return;
+    }
+    pushLog(`Added ${accepted.length} file(s).`);
+    setFiles((prev) => [...prev, ...accepted]);
+  }, [pushLog]);
+
+  const onDrop = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    onFilesChosen(event.dataTransfer.files);
+  }, [onFilesChosen]);
+
+  const onPick = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    onFilesChosen(event.target.files);
+    if (event.target.files) {
+      event.target.value = "";
+    }
+  }, [onFilesChosen]);
+
+  const removeFile = useCallback((name: string) => {
+    setFiles((prev) => prev.filter((file) => file.name !== name));
+  }, []);
+
+  const resetAll = useCallback(() => {
+    setFiles([]);
+    setUnits([]);
+    setInsights("");
+    setProgress(null);
+    clearLog();
+  }, [clearLog]);
+
+  const processFiles = useCallback(async () => {
+    if (!files.length) {
+      pushLog("Add PDF or PPTX files first.");
+      return;
+    }
+
+    setBusy(true);
+    setProgress("Preparing files...");
+    setInsights("");
+    setUnits([]);
+    clearLog();
+
+    try {
+      const results = await Promise.allSettled(
+        files.map(async (file, index) => {
+          pushLog(`(${index + 1}/${files.length}) Parsing ${describeFile(file)}...`);
+          const ext = file.name.split(".").pop()?.toLowerCase();
+          if (ext === "pdf") {
+            return await extractFromPDF(file);
+          }
+          if (ext === "pptx") {
+            return await extractFromPPTX(file);
+          }
+          pushLog(`Skipping unsupported file ${file.name}.`);
+          return [] as ExtractedUnit[];
+        })
+      );
+
+      const parsedUnits = results.flatMap((result, index) => {
+        if (result.status === "fulfilled") return result.value;
+        pushLog(`Failed to parse ${files[index].name}: ${result.reason}`);
+        return [] as ExtractedUnit[];
+      });
+
+      pushLog(`Parsed ${parsedUnits.length} unit(s).`);
+      setUnits(parsedUnits);
+
+      if (useOCR) {
+        let updatedCount = 0;
+        for (const unit of parsedUnits) {
+          if ((unit.text?.trim().length || 0) < 80 && unit.images?.length) {
+            setProgress(`Running OCR on ${unit.id}...`);
+            pushLog(`Running OCR for ${unit.id}.`);
+            const ocrText = await runOCR(unit.images);
+            unit.text = `${unit.text || ""}\n\n(ocr) ${ocrText}`;
+            updatedCount += 1;
+          }
+        }
+        if (updatedCount) pushLog(`OCR enriched ${updatedCount} unit(s).`);
+      }
+
+      pushLog("Extraction complete.");
+    } catch (error: any) {
+      console.error(error);
+      pushLog(`Extraction error: ${error.message || error}`);
+    } finally {
+      setBusy(false);
+      setProgress(null);
+    }
+  }, [files, useOCR, pushLog, clearLog]);
+
+  const runLLM = useCallback(async () => {
+    if (!units.length) {
+      pushLog("No parsed units yet. Extract documents first.");
+      return;
+    }
+
+    const handler = providerHandlers[provider];
+    const cfg = providerConfig;
+    const apiKey = apiKeys[cfg.envKey];
+    if (cfg.needsApiKey && !apiKey) {
+      pushLog(`Missing ${cfg.label} API key.`);
+      return;
+    }
+
+    setBusy(true);
+    setProgress(`Calling ${cfg.label} ...`);
+    setInsights("");
+
+    try {
+      const prompt = buildPrompt(units, { goal, level, ask, modelExtras });
+      pushLog(`Calling ${cfg.label} with ${units.length} unit(s).`);
+      const output = await handler(apiKey || "", prompt, units);
+      setInsights(output);
+      pushLog("LLM call complete.");
+    } catch (error: any) {
+      console.error(error);
+      pushLog(`LLM error: ${error.message || error}`);
+    } finally {
+      setBusy(false);
+      setProgress(null);
+    }
+  }, [provider, providerConfig, apiKeys, units, goal, level, ask, modelExtras, pushLog]);
+
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-900">
+      <header className="sticky top-0 z-20 border-b bg-white/80 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
+          <h1 className="text-2xl font-semibold">DocVision • PDF/PPTX → LLM Insights</h1>
+          <div className="flex items-center gap-2">
+            <select
+              className="rounded-xl border px-3 py-2"
+              value={provider}
+              onChange={(event) => setProvider(event.target.value as Provider)}
+            >
+              {providerOptions.map((option) => (
+                <option key={option.name} value={option.name}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <button
+              onClick={runLLM}
+              disabled={busy || !unitCount}
+              className="rounded-xl bg-slate-900 px-4 py-2 text-white disabled:opacity-40"
+            >
+              Run LLM
+            </button>
+          </div>
+        </div>
+        {progress && (
+          <div className="border-t bg-slate-900/90">
+            <div className="mx-auto max-w-6xl px-4 py-2 text-xs font-medium text-white">
+              {progress}
+            </div>
+          </div>
+        )}
+      </header>
+
+      <main className="mx-auto grid max-w-6xl gap-6 px-4 py-6 md:grid-cols-3">
+        <section className="space-y-4 md:col-span-1">
+          <div className="rounded-2xl border bg-white p-4 shadow-sm">
+            <div className="mb-2 flex items-center justify-between">
+              <h2 className="text-lg font-semibold">1) API Keys</h2>
+              <button
+                type="button"
+                onClick={resetAll}
+                className="text-xs font-medium text-slate-500 underline-offset-2 hover:underline"
+              >
+                Reset
+              </button>
+            </div>
+            <p className="mb-3 text-sm text-slate-600">Stored locally in your browser only.</p>
+            {providerOptions.map((option) => (
+              <div key={option.envKey} className="mb-2">
+                <label className="text-sm font-medium">{option.label}</label>
+                <input
+                  type="password"
+                  placeholder={option.envKey}
+                  value={apiKeys[option.envKey] || ""}
+                  onChange={(event) => onPutKey(option.envKey, event.target.value)}
+                  className="mt-1 w-full rounded-xl border px-3 py-2"
+                />
+              </div>
+            ))}
+          </div>
+
+          <div className="rounded-2xl border bg-white p-4 shadow-sm">
+            <h2 className="mb-2 text-lg font-semibold">2) Upload</h2>
+            <div
+              onDrop={onDrop}
+              onDragOver={(event) => event.preventDefault()}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  fileInputRef.current?.click();
+                }
+              }}
+              className="mb-2 grid place-items-center gap-2 rounded-xl border-2 border-dashed p-6 text-center focus:outline-none focus-visible:ring focus-visible:ring-slate-400"
+            >
+              <p className="text-sm text-slate-600">Drag & drop PDF or PPTX here</p>
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                className="rounded-lg border px-3 py-1 text-sm"
+                type="button"
+              >
+                Choose files
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".pdf,.pptx"
+                multiple
+                onChange={onPick}
+                className="hidden"
+              />
+            </div>
+            {files.length > 0 && (
+              <ul className="ml-5 list-disc text-sm text-slate-700">
+                {files.map((file) => (
+                  <li key={file.name} className="flex items-center justify-between gap-3 py-1">
+                    <span>{describeFile(file)}</span>
+                    <button
+                      type="button"
+                      onClick={() => removeFile(file.name)}
+                      className="text-xs text-rose-600 hover:underline"
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="mt-3 flex items-center justify-between">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={useOCR}
+                  onChange={(event) => setUseOCR(event.target.checked)}
+                />
+                Use OCR for charts/tables
+              </label>
+              <button
+                onClick={processFiles}
+                disabled={busy || files.length === 0}
+                className="rounded-xl border bg-white px-3 py-2 text-sm shadow disabled:opacity-40"
+              >
+                Extract
+              </button>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border bg-white p-4 shadow-sm">
+            <h2 className="mb-2 text-lg font-semibold">3) Request</h2>
+            <label className="text-sm font-medium">Goal / context</label>
+            <textarea
+              className="mt-1 w-full rounded-xl border px-3 py-2"
+              rows={3}
+              value={goal}
+              onChange={(event) => setGoal(event.target.value)}
+            />
+            <div className="mt-3 grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-sm font-medium">Depth</label>
+                <select
+                  value={level}
+                  onChange={(event) => setLevel(event.target.value as Level)}
+                  className="mt-1 w-full rounded-xl border px-3 py-2"
+                >
+                  <option value="overview">Overview</option>
+                  <option value="deep-dive">Deep Dive</option>
+                  <option value="exec-summary">Exec Summary</option>
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium">Custom hints (optional)</label>
+                <input
+                  value={modelExtras}
+                  onChange={(event) => setModelExtras(event.target.value)}
+                  className="mt-1 w-full rounded-xl border px-3 py-2"
+                  placeholder="e.g., extract all CAGR figures"
+                />
+              </div>
+            </div>
+            <label className="mt-3 block text-sm font-medium">Specific ask</label>
+            <textarea
+              className="mt-1 w-full rounded-xl border px-3 py-2"
+              rows={3}
+              value={ask}
+              onChange={(event) => setAsk(event.target.value)}
+            />
+          </div>
+
+          <div className="rounded-2xl border bg-white p-4 shadow-sm">
+            <h2 className="mb-2 text-lg font-semibold">Activity</h2>
+            <pre className="max-h-56 overflow-auto whitespace-pre-wrap rounded-lg border bg-slate-50 p-3 text-xs">
+              {logText || "No activity yet."}
+            </pre>
+          </div>
+        </section>
+
+        <section className="space-y-4 md:col-span-1">
+          <div className="rounded-2xl border bg-white p-4 shadow-sm">
+            <h2 className="mb-2 text-lg font-semibold">Parsed Units ({unitCount})</h2>
+            {!unitCount ? (
+              <p className="text-sm text-slate-600">Nothing yet. Extract first.</p>
+            ) : (
+              <ul className="max-h-[65vh] space-y-3 overflow-auto pr-2">
+                {units.map((unit) => (
+                  <li key={unit.id} className="rounded-xl border p-3">
+                    <div className="flex items-center justify-between">
+                      <div className="text-sm font-medium">
+                        {unit.kind === "pdf-page" ? "PDF Page" : "PPTX Slide"} #{unit.index}
+                      </div>
+                      <div className="text-xs text-slate-500">{unit.sourceName}</div>
+                    </div>
+                    <div className="mt-2 grid grid-cols-6 gap-3">
+                      <div className="col-span-2">
+                        {unit.thumb ? (
+                          <img
+                            src={unit.thumb}
+                            alt={unit.images[0]?.label || "Thumbnail"}
+                            className="h-28 w-full rounded-lg border object-cover"
+                          />
+                        ) : (
+                          <div className="grid h-28 place-items-center rounded-lg border text-xs text-slate-500">
+                            No preview
+                          </div>
+                        )}
+                      </div>
+                      <div className="col-span-4">
+                        <pre className="max-h-28 overflow-auto whitespace-pre-wrap text-xs text-slate-700">
+                          {(unit.text || "").slice(0, 800)}
+                        </pre>
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
+
+        <section className="space-y-4 md:col-span-1">
+          <div className="rounded-2xl border bg-white p-4 shadow-sm">
+            <h2 className="mb-2 text-lg font-semibold">LLM Output</h2>
+            {!insights ? (
+              <p className="text-sm text-slate-600">
+                Run the LLM to produce insights. Expected format is JSON with sections (highlights, key_metrics,
+                tables, risks, opportunities, actions).
+              </p>
+            ) : (
+              <pre className="max-h-[70vh] overflow-auto whitespace-pre-wrap text-xs leading-relaxed">{insights}</pre>
+            )}
+          </div>
+
+          <div className="rounded-2xl border bg-white p-4 shadow-sm">
+            <h2 className="mb-2 text-lg font-semibold">Tips</h2>
+            <ul className="ml-5 list-disc space-y-2 text-sm text-slate-700">
+              <li>If CORS blocks provider calls, proxy via your backend. Keep provider API keys server-side in production.</li>
+              <li>For higher PDF fidelity (tables), add PDF table detectors (tabula/camelot) on the server and merge results back.</li>
+              <li>Tune temperature to 0.0–0.3 for analytical tasks and set stricter JSON schemas with function calling where supported.</li>
+              <li>Attach only representative images to stay within multimodal token limits; stream remaining pages on demand.</li>
+            </ul>
+          </div>
+        </section>
+      </main>
+
+      <footer className="mx-auto max-w-6xl px-4 pb-10 text-center text-xs text-slate-500">
+        Built for rapid analysis. © {new Date().getFullYear()} DocVision.
+      </footer>
+    </div>
+  );
+}

--- a/ui/src/docvision/index.ts
+++ b/ui/src/docvision/index.ts
@@ -1,0 +1,3 @@
+export { default as DocVisionApp } from "./DocVisionApp";
+export * from "./types";
+export * from "./providers";

--- a/ui/src/docvision/ocr.ts
+++ b/ui/src/docvision/ocr.ts
@@ -1,0 +1,20 @@
+import { createWorker } from "tesseract.js";
+import type { ExtractedImage } from "./types";
+
+export async function runOCR(images: ExtractedImage[]) {
+  if (!images.length) return "";
+  const worker = await createWorker();
+  await worker.loadLanguage("eng");
+  await worker.initialize("eng");
+
+  try {
+    const chunks: string[] = [];
+    for (const img of images) {
+      const { data } = await worker.recognize(img.dataUrl);
+      chunks.push(data.text);
+    }
+    return chunks.join("\n\n");
+  } finally {
+    await worker.terminate();
+  }
+}

--- a/ui/src/docvision/pdf.ts
+++ b/ui/src/docvision/pdf.ts
@@ -1,0 +1,50 @@
+import type { ExtractedUnit } from "./types";
+import { canvasToDataURL, scaleCanvas } from "./rendering";
+
+const PDF_WORKER_SRC =
+  "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.5.136/pdf.worker.min.js";
+
+export async function extractFromPDF(file: File): Promise<ExtractedUnit[]> {
+  const pdfjs = await import("pdfjs-dist/build/pdf");
+  (pdfjs as any).GlobalWorkerOptions.workerSrc = PDF_WORKER_SRC;
+  const { getDocument } = pdfjs as any;
+
+  const pdf = await getDocument({ data: await file.arrayBuffer() }).promise;
+  const units: ExtractedUnit[] = [];
+
+  for (let i = 1; i <= pdf.numPages; i += 1) {
+    const page = await pdf.getPage(i);
+    const viewport = page.getViewport({ scale: 2 });
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("2d");
+    if (!context) continue;
+    canvas.width = viewport.width;
+    canvas.height = viewport.height;
+
+    await page.render({ canvasContext: context, viewport }).promise;
+
+    const pageImage = await canvasToDataURL(canvas, "image/png", 0.92);
+    const thumb = await canvasToDataURL(scaleCanvas(canvas, 300));
+    const textContent = await page.getTextContent();
+    const text = textContent.items.map((item: any) => item.str).join(" \n");
+
+    units.push({
+      id: `${file.name}#p${i}`,
+      kind: "pdf-page",
+      index: i,
+      text,
+      images: [
+        {
+          dataUrl: pageImage,
+          width: canvas.width,
+          height: canvas.height,
+          label: `page ${i}`,
+        },
+      ],
+      thumb,
+      sourceName: file.name,
+    });
+  }
+
+  return units;
+}

--- a/ui/src/docvision/pptx.ts
+++ b/ui/src/docvision/pptx.ts
@@ -1,0 +1,87 @@
+import JSZip from "jszip";
+import { XMLParser } from "fast-xml-parser";
+import type { ExtractedUnit } from "./types";
+
+type Relationship = {
+  "@_Id": string;
+  "@_Type": string;
+  "@_Target": string;
+};
+
+type RelationshipDocument = {
+  Relationships?: {
+    Relationship?: Relationship | Relationship[];
+  };
+};
+
+export async function extractFromPPTX(file: File): Promise<ExtractedUnit[]> {
+  const zip = await JSZip.loadAsync(await file.arrayBuffer());
+  const units: ExtractedUnit[] = [];
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "@_" });
+
+  async function toBlobUrl(path: string) {
+    const entry = zip.file(path);
+    if (!entry) return undefined;
+    const blob = new Blob([await entry.async("arraybuffer")]);
+    return URL.createObjectURL(blob);
+  }
+
+  let idx = 1;
+  while (zip.file(`ppt/slides/slide${idx}.xml`)) {
+    const slideXml = await zip.file(`ppt/slides/slide${idx}.xml`)!.async("string");
+    const relsPath = `ppt/slides/_rels/slide${idx}.xml.rels`;
+    const relsXml = zip.file(relsPath) ? await zip.file(relsPath)!.async("string") : undefined;
+
+    const slide = parser.parse(slideXml);
+    const rels = relsXml ? (parser.parse(relsXml) as RelationshipDocument) : undefined;
+
+    const texts: string[] = [];
+    const walk = (node: any) => {
+      if (!node || typeof node !== "object") return;
+      for (const [key, value] of Object.entries(node)) {
+        if (key.endsWith(":t") || key === "a:t") {
+          if (typeof value === "string") texts.push(value);
+        } else if (typeof value === "object") {
+          walk(value);
+        }
+      }
+    };
+    walk(slide);
+
+    const images = [] as ExtractedUnit["images"];
+    if (rels?.Relationships?.Relationship) {
+      const relationships = Array.isArray(rels.Relationships.Relationship)
+        ? rels.Relationships.Relationship
+        : [rels.Relationships.Relationship];
+      for (const rel of relationships) {
+        if (rel["@_Type"]?.includes("image")) {
+          const normalized = rel["@_Target"].replace(/^[.\\/]+/, "");
+          const path = `ppt/${normalized}`;
+          const url = await toBlobUrl(path);
+          if (url) {
+            images.push({
+              dataUrl: url,
+              width: 0,
+              height: 0,
+              label: `slide ${idx} image`,
+            });
+          }
+        }
+      }
+    }
+
+    units.push({
+      id: `${file.name}#s${idx}`,
+      kind: "pptx-slide",
+      index: idx,
+      text: texts.join(" \n"),
+      images,
+      thumb: images[0]?.dataUrl,
+      sourceName: file.name,
+    });
+
+    idx += 1;
+  }
+
+  return units;
+}

--- a/ui/src/docvision/prompt.ts
+++ b/ui/src/docvision/prompt.ts
@@ -1,0 +1,28 @@
+import type { ExtractedUnit, InsightRequest } from "./types";
+
+const MAX_TEXT = 3000;
+
+export function buildPrompt(units: ExtractedUnit[], req: InsightRequest) {
+  const header =
+    "You are a senior analyst. You will receive parsed content (text + images) from PDFs/PPTX.\n" +
+    `Your task: produce ${req.level} insights tied to page/slide citations. Create structured JSON sections:\n\n` +
+    '{"highlights": [ {"point": string, "evidence": string, "source": {"file": string, "pageOrSlide": number}} ],\n"key_metrics": [ {"name": string, "value": string, "unit": string|null, "source": {...}} ],\n"tables": [ {"title": string, "columns": string[], "rows": string[][], "source": {...}} ],\n"risks": string[], "opportunities": string[], "actions": string[] }\n\n' +
+    `Goal/context: ${req.goal}\nSpecific ask: ${req.ask}\n` +
+    (req.modelExtras ? `Model hints: ${req.modelExtras}\n` : "") +
+    "Use OCR in attached images if text is missing. If a chart is present, infer axes, units, and trends. Indicate uncertainty explicitly.";
+
+  const body = units
+    .map((unit) => {
+      return (
+        "\n\n=== SOURCE UNIT ===\n" +
+        `id: ${unit.id}\n` +
+        `kind: ${unit.kind}\n` +
+        `index: ${unit.index}\n` +
+        `file: ${unit.sourceName}\n` +
+        `text:\n${(unit.text || "").slice(0, MAX_TEXT)}`
+      );
+    })
+    .join("\n");
+
+  return `${header}\n${body}`;
+}

--- a/ui/src/docvision/providers.ts
+++ b/ui/src/docvision/providers.ts
@@ -1,0 +1,113 @@
+import type { ExtractedUnit, Provider } from "./types";
+
+export type ProviderConfig = {
+  name: Provider;
+  label: string;
+  needsApiKey: boolean;
+  envKey: string;
+};
+
+export const PROVIDERS: Record<Provider, ProviderConfig> = {
+  openai: { name: "openai", label: "OpenAI", needsApiKey: true, envKey: "OPENAI_API_KEY" },
+  gemini: { name: "gemini", label: "Google Gemini", needsApiKey: true, envKey: "GEMINI_API_KEY" },
+  grok: { name: "grok", label: "xAI Grok", needsApiKey: true, envKey: "XAI_API_KEY" },
+  qwen: { name: "qwen", label: "Alibaba Qwen", needsApiKey: true, envKey: "DASHSCOPE_API_KEY" },
+};
+
+type ProviderCall = (apiKey: string, prompt: string, units: ExtractedUnit[]) => Promise<string>;
+
+export const providerHandlers: Record<Provider, ProviderCall> = {
+  openai: async (apiKey, prompt, units) => {
+    const model = "gpt-4o-mini";
+    const content: any[] = [{ type: "text", text: prompt }];
+    for (const unit of units) {
+      if (unit.images?.[0]?.dataUrl) {
+        content.push({ type: "input_image", image_url: unit.images[0].dataUrl });
+      }
+    }
+    const res = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content }],
+        temperature: 0.2,
+      }),
+    });
+    if (!res.ok) throw new Error(`OpenAI API error: ${res.status}`);
+    const json = await res.json();
+    return json.choices?.[0]?.message?.content || "";
+  },
+  gemini: async (apiKey, prompt, units) => {
+    const parts: any[] = [{ text: prompt }];
+    for (const unit of units) {
+      const dataUrl = unit.images?.[0]?.dataUrl;
+      if (!dataUrl) continue;
+      const [meta, base64] = dataUrl.split(",");
+      const mimeType = meta.split(":")[1].split(";")[0];
+      parts.push({ inlineData: { data: base64, mimeType } });
+    }
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent?key=${apiKey}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ contents: [{ role: "user", parts }] }),
+      }
+    );
+    if (!res.ok) throw new Error(`Gemini API error: ${res.status}`);
+    const json = await res.json();
+    return json.candidates?.[0]?.content?.parts?.map((part: any) => part.text).join("") || "";
+  },
+  grok: async (apiKey, prompt, units) => {
+    const imageMarkdown = units
+      .filter((unit) => unit.images?.[0]?.dataUrl)
+      .map((unit) => `![${unit.id}](${unit.images[0].dataUrl})`)
+      .join("\n\n");
+    const res = await fetch("https://api.x.ai/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "grok-2-1212",
+        temperature: 0.2,
+        messages: [{ role: "user", content: `${prompt}\n\n${imageMarkdown}` }],
+      }),
+    });
+    if (!res.ok) throw new Error(`xAI API error: ${res.status}`);
+    const json = await res.json();
+    return json.choices?.[0]?.message?.content || "";
+  },
+  qwen: async (apiKey, prompt, units) => {
+    const messages: any[] = [{ role: "user", content: [{ text: prompt }] }];
+    const first = messages[0].content;
+    for (const unit of units) {
+      if (unit.images?.[0]?.dataUrl) {
+        first.push({ image: unit.images[0].dataUrl });
+      }
+    }
+    const res = await fetch(
+      "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({ model: "qwen-vl-plus", input: { messages } }),
+      }
+    );
+    if (!res.ok) throw new Error(`DashScope API error: ${res.status}`);
+    const json = await res.json();
+    return (
+      json.output?.text ||
+      json.output?.choices?.[0]?.message?.content ||
+      JSON.stringify(json.output || json)
+    );
+  },
+};

--- a/ui/src/docvision/rendering.ts
+++ b/ui/src/docvision/rendering.ts
@@ -1,0 +1,38 @@
+export function canvasToDataURL(
+  canvas: HTMLCanvasElement,
+  type: string = "image/png",
+  quality?: number
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error("Unable to export canvas to blob"));
+          return;
+        }
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = () => reject(reader.error || new Error("Failed to read canvas blob"));
+        reader.readAsDataURL(blob);
+      },
+      type,
+      quality
+    );
+  });
+}
+
+export function scaleCanvas(
+  source: HTMLImageElement | HTMLCanvasElement,
+  maxWidth: number = 512
+): HTMLCanvasElement {
+  const width = (source as any).width as number;
+  const height = (source as any).height as number;
+  const scale = width > maxWidth ? maxWidth / width : 1;
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.round(width * scale);
+  canvas.height = Math.round(height * scale);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Unable to acquire 2D context");
+  ctx.drawImage(source as any, 0, 0, canvas.width, canvas.height);
+  return canvas;
+}

--- a/ui/src/docvision/storage.ts
+++ b/ui/src/docvision/storage.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+export const LS_KEYS = {
+  provider: "docvision.provider",
+  apiKeys: "docvision.api_keys",
+} as const;
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+export function useLocalStorage<T extends JsonValue>(key: string, initial: T) {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === "undefined") return initial;
+    try {
+      const raw = window.localStorage.getItem(key);
+      return raw ? (JSON.parse(raw) as T) : initial;
+    } catch (err) {
+      console.warn(`[docvision] Failed to read localStorage key ${key}`, err);
+      return initial;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch (err) {
+      console.warn(`[docvision] Failed to persist localStorage key ${key}`, err);
+    }
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}

--- a/ui/src/docvision/types.ts
+++ b/ui/src/docvision/types.ts
@@ -1,0 +1,26 @@
+export type Provider = "openai" | "gemini" | "grok" | "qwen";
+export type Level = "overview" | "deep-dive" | "exec-summary";
+
+export type ExtractedImage = {
+  dataUrl: string;
+  width: number;
+  height: number;
+  label?: string;
+};
+
+export type ExtractedUnit = {
+  id: string;
+  kind: "pdf-page" | "pptx-slide";
+  index: number;
+  text: string;
+  images: ExtractedImage[];
+  thumb?: string;
+  sourceName: string;
+};
+
+export type InsightRequest = {
+  goal: string;
+  level: Level;
+  ask: string;
+  modelExtras?: string;
+};


### PR DESCRIPTION
## Summary
- add a modular DocVision React experience with activity logging, progress feedback, and file management for PDF/PPTX analysis
- break out parsing, OCR, prompt construction, and provider adapters into focused modules for reuse
- document how to embed the DocVision app and required dependencies in the UI README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68eb3027ad288328a302f808fb38d1fd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced DocVision: a self-contained UI to upload PDFs/PPTX, parse slides/pages, and generate insights with multimodal AI.
  - Supports drag-and-drop, progress/activity logs, reset, and resilient UX.
  - Optional OCR to extract text from images.
  - Configurable requests (goal, depth, custom hints, specific ask).
  - Flexible provider selection (OpenAI, Gemini, Grok, Qwen) with API key management.
  - Local persistence for provider and keys, plus improved thumbnail/image rendering.

- Documentation
  - Added setup and usage instructions, including installation and example integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->